### PR TITLE
allow notifications on android 13, read notification text from custom http header

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET"  tools:remove="android:maxSdkVersion"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Hi,
the original code only displays 'successful' or ' Error — unable to call endpoint'. 
This commit allows you to recover notification text from a custom header. 
For instance, in php, the headers :
header("X-Success-Message: Return Value");
header("X-Error-Message: Error Code");
will display :
"Return Value"
"Error Code" 
as notification.
You can find an usage example at :
https://gitub.u-bordeaux.fr/phericou/alarm
Regards
Pierre